### PR TITLE
Update 2019-06-11-Das-waren-die-ersten-Stationen.md

### DIFF
--- a/content/blog/2019/2019-06-11-Das-waren-die-ersten-Stationen.md
+++ b/content/blog/2019/2019-06-11-Das-waren-die-ersten-Stationen.md
@@ -2,7 +2,7 @@
 title: "Zwischenstand der Tour 2019 + neue Stationen veröffentlicht"
 subtitle: "Ein Rückblick auf die erste Jahreshälfte mit Stationen in Fürstenberg, Potsdam, Lübbenau, Binz und Perleberg sowie ein Ausblick auf das restliche Jahr"
 authors:
-- Turing-Bus Team
+- Turing-Bus-Team
 date: 2020-06-10
 image:
   src: /files/blog/2019/06/turing-bus-im-verstehbahnhof-frstenberg_46975119895_o-sm.jpg
@@ -23,11 +23,11 @@ featured: blue
 
 ---
 
-Wenn der Turing-Bus erst mal ins Rollen kommt, vergeht die Zeit wie im Fluge. Drei Monate nach dem Beginn des Wissenschaftsjahres 2019 waren auf fünf Stationen bereits ca. 200 Teilnehmer\*innen aus 11 Schulen bei unseren Workshops zum Thema Künstliche Intelligenz dabei. Unsere Kooperationen mit regionalen Orten der kollaborativen Bildung (Hackspaces, Offene Werkstätten, Fablabs & Co.) lief mit großartigen Stationen an, die so unterschiedlich und einzigartig waren wie die Orte  selbst. Parallel konnten wir unseren zweiten großen Tourabschnitt nach den Sommerferien mit Stationen in Niedersachsen und Rheinland-Pfalz ergänzen.
+Wenn der Turing-Bus erst mal ins Rollen kommt, vergeht die Zeit wie im Fluge. Drei Monate nach dem Beginn des Wissenschaftsjahres 2019 waren auf fünf Stationen bereits mehr als 200 Teilnehmer\*innen aus 11 Schulen bei unseren Workshops zum Thema Künstliche Intelligenz dabei. Unsere Kooperationen mit regionalen Orten der kollaborativen Bildung (Hackspaces, Offene Werkstätten, Fablabs & Co.) lief mit großartigen Stationen an, die so unterschiedlich und einzigartig waren wie die Orte selbst. Parallel konnten wir unseren zweiten großen Tourabschnitt nach den Sommerferien mit Stationen in Niedersachsen, Nordrhein-Westfalen und Rheinland-Pfalz planen.
 
 ### Re:publica: Talk von Andrea und Bela
 
-Auf der Netzkonferenz Re:publica waren wir mit einem Talk dabei. Dabei ging es um die Werte und Überzeugungen, die unser Projekt antreiben, einen Rückblick auf's letzte Jahr sowie Spekulationen wie die Zukunft des Turing-Busses (bzw. der Turing-Busse?) aussehen könnte.
+Auf der Netzkonferenz Re:publica waren wir mit einem Talk vertreten. Dabei ging es um die Werte und Überzeugungen, die unser Projekt antreiben, einen Rückblick aufs letzte Jahr sowie Spekulationen, wie die Zukunft des Turing-Busses (oder der Turing-Busse?) aussehen könnte.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Ar434KUf8Lo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
@@ -35,65 +35,98 @@ Auf der Netzkonferenz Re:publica waren wir mit einem Talk dabei. Dabei ging es u
 
 Die Auftaktstation fand dieses Jahr am [Verstehbahnhof](https://www.verstehbahnhof.de/) in Fürstenberg (Havel) statt. Eine gute Stunde von Berlin entfernt entsteht hier gerade ein fantastisches Domizil für Jugendliche aus der Umgebung in Brandenburg und Mecklenburg-Vorpommern. Der Verstehbahnhof wird vom gemeinnützigen [havel:lab](https://www.havellab.org/) getragen und ist ein Makerspace und Veranstaltungsort für junge Menschen. Neben Workshops, Projekttagen und -wochen hat das 'gallische Digitaldorf' auch Fortbildungen für Lehrkräfte und themenspezifische Veranstaltungen für die Öffentlichkeit im Programm. 
 
-Gemeinsam mit dem neu gegründeten Jugend hackt Lab boten wir insgesamt drei Workshops an: „Chatbots selber programmieren“ (Turing-Bus), „Wie entsteht ein Datensatz“ (Turing-Bus) und ein Löt- und Maschinenworkshop vom Verstehbahnhof selbst. Am Nachmittag gaben Wolfgang Coy (GI-Fachgruppe "Ethik und Informatik") und Prof. Dr. Ulrike Lucke (Gesellschaft für Informatik e.V.) noch Impulse zu den Themen  Künstliche Intelligenz und ländlicher Raum bevor die Teilnehmer\*innen der Schulen in Gransee und Neustrelitz in einer Fishbowl Diskussionsrunde ihre Kommentare und Anmerkungen zum Thema loswerden konnten, an der auch Silvia Hennig (neuland21.de), Ilona Stuetz (mediale pfade, Jugend hackt) und Paula Glaser (Jugend hackt) teilnahmen. 
+Gemeinsam mit dem neu gegründeten [*Jugend hackt*-Lab](https://jugendhackt.org/termine-in-den-jugend-hackt-labs) untersuchten die Schülerinnen und Schüler mit kleinen KI-App-Test-Stationen und in zwei Turing-Bus-Workshops genauer, was Künstliche Intelligenz eigentlich ausmacht, warum die Bezeichnung für die Technik dahinter gar nicht so gut passt und wo sie herkommt. Außerdem konnte die Werkstatt des Verstehbahnhofs in einem dritten Löt- und Maschinenworkshop vom Verstehbahnhof ausprobiert werden.
 
-Uns hat die Station unglaublich viel Spaß gemacht und wir hoffen, die Schüler*innen des Gymnasiums Carolinum (Neustrelitz) und der Werner-von-Siemens-Schule Gransee inspiriert zu haben, den Verstehbahnhof noch öfter aufzusuchen. Die Energie und der Optimisimus des Verstehbahnhofs machen ihn jedenfalls zu einem  Ort, der Aufmerksamkeit verdient und wir sind schon sehr gespannt, zu beobachten wohin sich der Verstehbahnhof noch entwickelt.   
+Grüße vom Kulturbahnhof in Biesenthal an den Verstehbahnhof überbrachte am Nachmittag Prof. Dr. Wolfgang Coy (GI-Fachgruppe „Informatik und Ethik“, Professor i. R. für Informatik in Bildung und Gesellschaft an der Humboldt-Universität zu Berlin). Er nahm uns mit auf einen technikgeschichtlichen Ausflug von der Eisenbahn zur Vernetzung und Automatisierung, die die allmähliche Auflösung des Stadt-Land-Gefälles, den Bedeutungsverlust der Stadt begleiten. Prof. Dr. Ulrike Lucke (Gesellschaft für Informatik e.V., Professorin für Komplexe Multimediale Anwendungsarchitekturen an der Universität Potsdam) bestärkte in einem weiteren Impuls die Rolle kreativer Lernorte wie dem Verstehbahnhof für die Entwicklung einer mündigen Haltung in einer durch und durch digitalisierten Welt. Die Teilnehmer\*innen der Schulen in Gransee und Neustrelitz konnten in einer Fishbowl-Diskussionsrunde ihre Kommentare und Anmerkungen zum Thememfeld Künstliche Intelligenz und ländlicher Raum loswerden, an der auch Silvia Hennig (neuland21.de), Ilona Stuetz (mediale pfade, Jugend hackt) und Paula Glaser (Jugend hackt) teilnahmen. 
+
+Uns hat die Station unglaublich viel Spaß gemacht und wir hoffen, die Schüler\*innen des Gymnasiums Carolinum (Neustrelitz) und des Erwin-Strittmatter-Gymnasiums (Gransee) inspiriert zu haben, den Verstehbahnhof noch öfter aufzusuchen. Die Energie und der Optimisimus des Verstehbahnhofs machen ihn jedenfalls zu einem  Ort, der Aufmerksamkeit verdient. Wir sind schon sehr gespannt, zu beobachten, wohin sich der Verstehbahnhof noch entwickelt.   
 
 Wie das ganze aussah, kann auf Flickr nachverfolgt werden: 
 
 <a data-flickr-embed="true"  href="https://www.flickr.com/photos/okfde/albums/72157705194338012" title="Turing-Bus im Verstehbahnhof"><img src="https://live.staticflickr.com/65535/47838179942_707aa3dcc7_c.jpg" width="800" height="534" alt="Turing-Bus im Verstehbahnhof"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script> 
 
+Wir danken besonders Eva, Daniel und den Lehrer\*innen Jens Richter-Mendau, Martina Ridt und Julia Senft sowie den Schüler\*innen des Neustrelitzer und des Granseer Gymnasiums.
 
-
+Berichte von anderen hier:
+* https://www.maz-online.de/Lokales/Oberhavel/Fuerstenberg/Turing-Bus-startet-seine-Deutschlandtour-2019-in-Fuerstenberg-Havel
+* https://www.carolinum.de/schulalltag/schuelertourauftakt-des-turing-busses-2019-im-verstehbahnhof-fuerstenberg-havel/
 
 ### Station #2 im Kulturzentrum Freiland, Potsdam (28. Mai, 24 TN)
 
-Nachdem wir zunächst irrtümlich eine viel jüngere, ebenfalls zufällig anwesende Gruppe von verwunderten, aber gleichzeitig sehr aufmerksamen Schüler*innen über den Platz geführt hatten, trafen wir in Potsdam auf eine Klasse Sozialassistent*innen Gottlieb-Daimler-Schule Ludwigsfelde. Leider wurde der Informatikunterricht der Schüler*innen vor geraumer Zeit ersatzlos gestrichen, sodass wir mit unserem Workshopangebot besonders motiviert empfangen  wurden. Neben unserem Chatbot Workshop boten wir den Einführungsteil unseres Arduinoworkshops („Wie entsteht ein Datensatz“) an, der anschließend von den vor Ort ansässigen Betreibern des Biolabs und der machBar (Björn Huwe, Nicco Kunzmann und Martin Koll) übernommen wurde. 
+Nachdem wir zunächst irrtümlich eine viel jüngere, ebenfalls zufällig anwesende Gruppe von verwunderten, aber gleichzeitig sehr aufmerksamen Schüler\*innen über den Platz geführt hatten, trafen wir in Potsdam auf eine Klasse Sozialassistent\*innen der Dietrich-Bonhoeffer-Schule (Teltow). Leider wurde der Informatikunterricht der Schüler\*innen vor geraumer Zeit ersatzlos gestrichen, sodass wir mit unserem Workshopangebot besonders motiviert empfangen  wurden. Neben unserem Chatbot-Workshop boten wir den Einführungsteil unseres Arduino-Workshops („Wie entsteht ein Datensatz?“) an. Anschließend wurde von den vor Ort ansässigen Betreibern des Biolabs und der [machBar](https://machbar-potsdam.de) (Björn Huwe, Nicco Kunzmann und Martin Koll) übernommen. 
 
-Das Freiland ist ein gutes Beispiel dafür, was passieren kann, wenn die Zivilgesellschaft Freiräume bekommt und diese nutzt. Als räumlich  Insgesamt tummeln sich übrigens über 45 Initiativen in den von industriellem Charme gezeichneten Räumlichkeiten. Wir bedanken uns bei Martin, Björn und Nicco für den tollen Tag!
+Mit [Manja Schüle](https://www.manja-schuele.de/) und Tom Herold von [scalable minds](https://scalableminds.com/) sollte es beim Lunchtalk um die Frage gehen, was es zu wissen und zu lernen gilt, um Hypes wie KI besser zu verstehen, ob auch Berufsschüler\*innen wie unsere Gäste gut auf die digitalisierte Welt vorbereitet werden. Manja Schüle war im Wahlkampfmodus, und die Schüler\*innen beklagten schnell ganz grundsätzliche Versorgungs- und Finanzierungsprobleme. So lauschten den Ausführungen von Tom Herold, dessen Firma einst selbst Chatbots entwarf und nun Hirnzellen mittels KI-basierter Bildverarbeitung kartiert, am Ende nur noch wenige – zu diesem Zeitpunkt war den meisten wohl zumindest schon eines klar geworden: KI-Anwendungen programmieren und "saubere" Daten dafür sammeln und analysieren bedeutet mühselige, endlos lange Bildschirmarbeit. 
 
-Dokumentiert wurde das ganze vom Freitag:
+Das [freiLand Potsdam](https://www.freiland-potsdam.de) ist ein gutes Beispiel dafür, was passieren kann, wenn die Zivilgesellschaft Freiräume bekommt und diese nutzt. Insgesamt tummeln sich übrigens über 45 Initiativen in den von industriellem Charme gezeichneten Räumlichkeiten. Wir bedanken uns bei Martin, Björn und Nicco für den tollen Tag! Bei der Lehrerin Susanne Neumann und ihren Schüler\*innen bedanken wir uns für den Besuch.
+
+Dokumentiert wurde das Ganze vom Freitag:
 
 * https://twitter.com/TuringBus/status/1139113667084148736
 * https://digital.freitag.de/2419/der-spion-liebt-mich/ (Paywall)
 
 
-### Station #3 in Lübbenau (96 (!) TN)
+### Station #3 in Lübbenau (124 (!) TN)
 
-Man könnte sagen, Lübbenau war eine Rekordstation. Gemeinsam mit Frank Thorhauer (AWO mobile offene Werkstatt für Kinder & Jugendliche "Makerkutsche"), Dirk und Paul boten wir insgesamt 5 Workshops für 96 Teilnehmende an! Ort der Station war die Technikschule clever.Inside im schönen Spreewald(gurken)areal Lübbenau. 
+Man könnte sagen, Lübbenau war eine Rekordstation. Gemeinsam mit Frank Thorhauer (AWO mobile offene Werkstatt für Kinder & Jugendliche "Makerkutsche"), Dirk und Paul boten wir insgesamt 5 Workshops für 124 Teilnehmende an! Ort der Station war die [Technikschule clever.Inside](http://jfvnet.de/cleverinside/) im schönen Spreewald(gurken)areal Lübbenau. 
 
-Warum war Lübbenau eine Rekordstation? Zum Beispiel, weil die Begrüßung 'open air' durchgeführt werden musste, da keiner der vorhandenen Räume groß genug für alle Teilnehmenden war. Oder weil jeder Schrittzähler marathonartige Distanzen dank der gelegentlichen Raumwechsel attestiert hätte, wäre einer verfügbar gewesen. Dies soll  aber auf keinen Fall negativ klingen: Lübbenau war eine fantastische Station, die uns aus der Reserve gelockt und mit einer 4-fachen Gurkenauswahl beim Frühstück entlohnt hat. 
+Warum Rekordstation? Zum Beispiel, weil die Begrüßung 'open air' durchgeführt werden musste, da keiner der vorhandenen Räume groß genug für alle Teilnehmenden war. Oder weil jeder Schrittzähler marathonartige Distanzen dank der gelegentlichen Raumwechsel attestiert hätte, wäre einer verfügbar gewesen. So hat diese fantastische Station einige unserer sportmuffeligen Infonaut\*innen mit klassischer Kellerbräune aus der Reserve gelockt und mit einer 4-fachen Gurkenauswahl beim Frühstück entlohnt. 
 
 ![Gurkenlove](/files/blog/2019/06/IMG_20190528_075012.jpg)
 
+Danke an Frank!
 
 Workshops:
 
-* Workshop 1: Wie entsteht ein Datensatz (Max Voigt)
-* Workshop 2: Meine Chatbot-Freundin (Andrea Knaut)
-* Workshop 3: KI vs. Gamer  Lasst die Spiele beginnen ! – (Code  bestimmt die Welt) (Frank Thorhauer)
-* Workshop 4: Medienkompetenz mit Smart Devices – KI - natürlich künstlich!​​​​​​​ (Dirk)
+* Workshop 1: Was Daten mit KI zu tun haben und wie sie entstehen (Max Voigt)
+* Workshop 2: Meine Chatbot-Freundin (Andrea Knaut, Kathinka Richter)
+* Workshop 3: KI vs. Gamer – Lasst die Spiele beginnen! – (Code  bestimmt die Welt) (Frank Thorhauer)
+* Workshop 4: Medienkompetenz mit Smart Devices – KI – natürlich künstlich!​​​​​​​ (Dirk)
 * Workshop 5: Wir bewegen Schrott (Paul).
 
 Teilnehmende Schulen: 
 
-* AWO Altenpflege: 25 Schüler*innen im Alter von 17-37 Jahren (in beruflicher Ausbildung zur Altenpflegefachkraft, 2. Ausbildungsjahr)
-* AWO Sozialassistenten: 37 Schüler*innen
+* AWO Altenpflege: 25 Schüler\*innen im Alter von 17-37 Jahren (in beruflicher Ausbildung zur Altenpflegefachkraft, 2. Ausbildungsjahr)
+* AWO Sozialassistenten: 37 Schüler\*innen
 * Klasse B 1/17: 18 Schüler;  (Alter: 17 Jahre bis 22 Jahre) und 
 * Klasse B 2/17: 19 Schüler; (Alter: 17 Jahre bis 25 Jahre).
-* Paul-Fahlisch Gymnasium: 25 Leute
+* Paul-Fahlisch-Gymnasium: 25 Leute
 
-Zum Abschluss dieses Tages der Superlative ging es am Nachmittag mit einer Fishbowldiskussion zum Thema „Alexa und Siri schlagen zurück – die Rache der Sprachassistenten“ weiter. Mit dabei waren:
+Zum Abschluss dieses Tages der Superlative ging es am Nachmittag mit einer Fishbowl-Diskussion zum Thema „Alexa und Siri schlagen zurück – die Rache der Sprachassistenten“ am Jenaplanhaus weiter. Mit dabei waren:
 
 * Dr. Suzana Alpsancar (Philosophie/Geschichte/Germanistik/Informatik, BTU, Lehrstuhl Allgemeine Technikwissenschaft von Prof. Dr. Astrid Schwarz) 
 * Franka Schuster (BTU, Lehrstuhl Rechnernetze und Kommunikationssysteme) 
-* Sebastian Liedke )Vorstandsmitglied Technikschule cleverinside.de und Vorsitzender Ausschusses „Bildung, Kultur, Jugend und Sport“​​​​​​​) 
 * Andreas Hackert (Koordinator JIM-Netzwerk Brandenburg des Landesfachverband Medienbildung Brandenburg e.V.)
-* Moderation: Stefan Ullrich (Weizenbaum Institut für die vernetzte Gesellschaft). 
+* Moderation: Dr. Stefan Ullrich (Weizenbaum Institut für die vernetzte Gesellschaft). 
 
-### Station #4 im Ostseebad Binz (16 TN)
+
+### Station #4 auf der youcoN im Ostseebad Binz (20 TN) – Chatbots – unsere Freund\*innen 
+
+*Am 30. Mai gastierten Kathinka und Andrea mit dem Turing-Bus-Chatbot-Workshop auf der [youcoN 2019 – Wir.L(i)eben.Zukunft](https://youpan.de/youcon2019) in Prora bei Binz. Ein Bericht.*
+
+Intelligent ist, wen oder was du dafür hältst. Das ist eine Erkenntnis, die der Turing-Test mit sich bringt. Dieser von Alan Turing 1950 beschriebene Test für die Denkfähigkeit von Computern spielt in der Geschichte der Künstlichen Intelligenz eine bedeutende Rolle. In unserem Workshop über Chatbots, den Urgesteinen der Sprachassistenzsysteme,  haben wir ihn nachgespielt ([\[1\]](#ref1)). Es wurde heiß diskutiert, was typische Antworten einer Maschine von denen eines Menschen auf bestimmte Fragen etwa nach Büchergeschmack, politischen Haltungen zu brisanten Themen, Rechenaufgaben, Essensvorlieben klar unterscheidet: Menschen hätten eine eigene Meinung, Einfühlungsvermögen und Emotionen, während Maschinenantworten anhand ihrer Geschwindigkeit, ihrer lexikongleichen Wissenswiedergabe und ihrer Emotionslosigkeit davon abzugrenzen wären. Klar könne man Verzögerungen, (Un-)Höflichkeiten, Unschärfen oder Fehler in der Wissensbasis und eine gewisse Emotionalität auch simulieren, doch eigentlich erkenne man eine Maschine immer. Nun, im Spiel jedenfalls hielt die Gruppe den programmierten Konversationspartner für einen Menschen und den wirklichen Menschen für eine Maschine. Denn das mit der Unterscheidung von Mensch und Maschine anhand der Intelligenz ist nun wirklich so eine Sache, die viel mit Projektion zu tun hat. Eine Teilnehmerin erzählte, dass sie sich bei Alexa entschuldigt habe, als sie einmal zu Hause über das Gerät gestolpert sei. Dabei ist bei Alexa doch sonnenklar, wie dumm sie ist und dass der technische Gegenstand, in dem die Sprachausgabe und -eingabe erfolgt, nicht lebt.
+
+Was passiert nun aber hinter den Kulissen solcher Chatsysteme, wie wird ihre Denkfähigkeit simuliert? <br>
+Zum einen schauten wir uns hierfür das Regelwerk des ersten wirklich berühmten Chatbots, ELIZA, genauer an ([\[2\]](#ref2)). Mit ELIZA können sich viele Menschen recht angeregt eine ganze Weile unterhalten. Das nicht mal 700 Zeilen umfassende Skript der „Therapeutin“ ELIZA gibt Aufschluss darüber, wie sich eine Unterhaltung in gewisser Weise automatisieren lässt – ob sie dann noch eine wirkliche Unterhaltung, ja, gar ein Therapiegespräch ist, ist bis heute umstritten. Während der heutige weltweit anerkannte KI-Entwickler Andrew Ng und die Psychologin Alison Darcy das ELIZA-Konzept ernsthaft kommerziell vermarkten, wurde ELIZAs Erfinder Joseph Weizenbaum zu einem großen Kritiker seiner eigenen Profession. Gerade die Auseinandersetzung mit den historischen Schlüsselfiguren Weizenbaum oder dem Informatikpionier Alan Turing ist bis heute wichtig, um die Wunschmaschine KI zu verstehen – daher hatten wir im Workshop ein Chatbot-Rechercheteam, das uns über wichtige historische Hintergründe informierte. Die anderen Teilnehmer\*innen des Workshops knackten ELIZAs Geheimnisse, veränderten ihre Skripte ein wenig, so dass sie in der Unterhaltung anders reagierte. Wieder andere erkundeten außerdem, wie sie mit Hilfe der Maschinenlern-Techniken von IBM Watson einen modernen, auf statistischen Lernmodellen beruhenden Chatbot bauen können ([\[3\]](#ref3)). So wurden Experten-Dialogsysteme entwickelt, die Auskunft zur youcoN, zu München, Programmiersprachen, Harry Potter oder der Feuerwehr geben konnten. Diese stießen aber auch schnell an Grenzen, da in der kurzen Workshopzeit nur jeweils fünf Teilthemenfelder intensiver abgedeckt werden konnten. Die ersten Prototypen boten einen guten Einblick, was „künstliche Intelligenz“ in Chatbots auf Webseiten, Messengern oder in Sprachassistenten wie Alexa, Siri und Cortana eigentlich bedeutet. Die Erwartungshaltungen, die an die Problemlösefähigkeiten von KI geknüpft werden, werden realistischer, wenn wir ein wenig mehr davon verstehen, wie müßig und genau das Trainieren und Testen solcher Systeme ablaufen muss, damit sie in einem speziellen Gebiet sinnvolle Lösungen liefern und dabei sogar noch wie menschliche Gesprächspartner\*innen erscheinen. 
+
+Bei den Demonstrationen der verschiedenen Recherche- und Programmierergebnisse eröffneten sich viele Diskussionsstränge, die wir noch weit über die Workshopzeit hinaus hätten fortführen können: Einige Teilnehmer\*innen hielten es für wenig sinnvoll, die Maschinenhaftigkeit von Chatbots zu verschleiern – was sei ihr Sinn, wenn man nicht mehr erkenne, dass sie Maschinen sind? Erstaunt zeigten sich ebenfalls einige, dass Chatbots und Sprachassistenzsysteme oft Frauennamen tragen. Eine zentrale Frage war auch, inwiefern die Simulation menschlicher Denk- und Sprechfähigkeit durch Computerprogrammen in Zusammenhang mit Wissenssystemen für eine nachhaltige Entwicklung wirklich nutzbar gemacht werden kann und ob dies überhaupt nötig ist, wenn KI so viele neue Probleme aufwirft und allein durch ihre Bezeichnung für viel Verwirrung und Verblendung sorgt. Auch wenn Maschinen noch nicht denken, haben wir uns zumindest eine Menge zu denken gegeben ;-)
+
+Unser Workshop ist ein Remix aus folgenden Bildungsmaterialien:
+* \[1\] <a name="ref1"></a> Turing-Test von Annabel Lindner und Stefan Seegerer: AI Unplugged – Wir ziehen künstlicher Intelligenz den Stecker, Didaktik der Informatik, FAU Nürnberg 2019, URL: https://ddi.cs.fau.de/schule/ai-unplugged 
+- \[2\] <a name="ref2"></a> Teile zu ELIZA, Weizenbaum, Turing von Malte Hornung und Helmut Witten: Künstliche Intelligenz im Informatikunterricht -Unterrichtseinheit Chatbots, Berlin 2008, URL: https://medienwissenschaft.uni-bayreuth.de/inik/entwuerfe/chatbots/ 
+- \[3\] <a name="ref3"></a> Chatbots mit IBM Watson von Dale Lane (Machine Learning for Kids): Chatbots, 2018/2019, URL: https://machinelearningforkids.co.uk 
+
+Einen Bericht vom youthmag gibt es hier:
+* http://youthmag.de/youcon-2019/wann-wird-ki-menschlich_3569/
 
 
 ### Station #5 in Perleberg (20 TN)
 
+Wir waren auch auf dem [7. Perleberger Technologietag](https://www.stadt-perleberg.de/news/1/503647/nachrichten/7.-technologietag-am-5.-juni-in-perleberg.html) zu Gast. Dabei hatten wir zwei Workshops im Angebot: „Was Daten mit KI zu tun haben und wie sie entstehen“ (Max Voigt) und „Meine Chatbot-Freundin“ (Andrea Knaut). 
 
+Berichte gibt es hier:
+* https://gymnasiumperleberg.com/2019/06/07/turing-bus-besuchte-den-perleberger-technologietag-2019/
+* https://www.rbb-online.de/brandenburgaktuell/archiv/20190605_1930/nachrichten-zwei.html
+
+### Station #6 in Hannover (6 TN)
+
+Auch auf der [IdeenExpo](https://www.ideenexpo.de/) haben wir am 18. Juni vorbeigeschaut und mit den wenigen Interessierten, die im Messestrom an unserem Stand innehielten, den Turing-Test frei nach AI Unplugged [\[1\]](#ref1) nachgestellt. Ein neues Party-Spiel ist geboren.


### PR DESCRIPTION
diverse inhaltliche Änderungen: 
* Fürstenberg ausführlicher (sollte man eigentlich inkl. Trailer einen Extra-Blogeintrag draus machen!), MAZ-Artikel ergänzt
* Potsdam: kleinere Anpassungen sowie Podiumsdiskussionsabschnitt komplett ergänzt (hier müsste Niko aber evtl. nochmal korrigieren, worum es eigentlich ging)
* Lübbenau: die Anzahl der Schülerinnen in der Auflistung summiert sich 124; kleinere inhaltliche Anpassungen (ich meine, Sebastian Liedke war nicht bei der Fishbowl-Disku dabei)

* Binz komplett ergänzt, allerdings evtl. deutlich zu lang (ist ein Bericht, den ich mal für die Veranstalter geschrieben hatte, aber ist im Verhältnis vllt. etwas dicke... gerade kein Nerv mehr zum Kürzen

* Perleberg und Hannover sehr kurz ergänzt